### PR TITLE
Tutorial#3 How to build a screen in an Expo app

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -11,7 +11,7 @@ export default function Index() {
         <ImageViewer imgSource={PlaceholderImage} />
       </View>
       <View style={styles.footerContainer}>
-        <Button label="Choose a photo" />
+        <Button label="Choose a photo" theme="primary" />
         <Button label="Use this photo" />
       </View>
     </View>

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,5 +1,6 @@
 import { View, StyleSheet } from 'react-native';
 import ImageViewer from '@/components/ImageViewer';
+import Button from '@/components/Button';
 
 const PlaceholderImage = require('@/assets/images/background-image.png');
 
@@ -8,6 +9,10 @@ export default function Index() {
     <View style={styles.container}>
       <View style={styles.imageContainer}>
         <ImageViewer imgSource={PlaceholderImage} />
+      </View>
+      <View style={styles.footerContainer}>
+        <Button label="Choose a photo" />
+        <Button label="Use this photo" />
       </View>
     </View>
   );
@@ -21,5 +26,9 @@ const styles = StyleSheet.create({
   },
   imageContainer: {
     flex: 1,
+  },
+  footerContainer: {
+    flex: 1 / 3,
+    alignItems: 'center',
   },
 });

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,9 +1,14 @@
-import { Text, View, StyleSheet } from 'react-native';
+import { View, StyleSheet } from 'react-native';
+import { Image } from 'expo-image';
+
+const PlaceholderImage = require('../../assets/images/background-image.png');
 
 export default function Index() {
   return (
     <View style={styles.container}>
-      <Text style={styles.text}>Hello Expo!</Text>
+      <View style={styles.imageContainer}>
+        <Image source={PlaceholderImage} style={styles.image} />
+      </View>
     </View>
   );
 }
@@ -11,16 +16,15 @@ export default function Index() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    justifyContent: 'center',
     alignItems: 'center',
     backgroundColor: '#25292e',
   },
-  text: {
-    color: '#fff',
+  image: {
+    width: 320,
+    height: 440,
+    borderRadius: 18,
   },
-  button: {
-    fontSize: 20,
-    textDecorationLine: 'underline',
-    color: '#fff',
+  imageContainer: {
+    flex: 1,
   },
 });

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,13 +1,13 @@
 import { View, StyleSheet } from 'react-native';
-import { Image } from 'expo-image';
+import ImageViewer from '@/components/ImageViewer';
 
-const PlaceholderImage = require('../../assets/images/background-image.png');
+const PlaceholderImage = require('@/assets/images/background-image.png');
 
 export default function Index() {
   return (
     <View style={styles.container}>
       <View style={styles.imageContainer}>
-        <Image source={PlaceholderImage} style={styles.image} />
+        <ImageViewer imgSource={PlaceholderImage} />
       </View>
     </View>
   );
@@ -18,11 +18,6 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: 'center',
     backgroundColor: '#25292e',
-  },
-  image: {
-    width: 320,
-    height: 440,
-    borderRadius: 18,
   },
   imageContainer: {
     flex: 1,

--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -1,0 +1,44 @@
+import { StyleSheet, View, Pressable, Text } from 'react-native';
+
+type Props = {
+  label: string;
+};
+
+export default function Button({ label }: Props) {
+  return (
+    <View style={styles.buttonContainer}>
+      <Pressable
+        style={styles.button}
+        onPress={() => alert('You pressed a button!')}
+      >
+        <Text style={styles.buttonLabel}>{label}</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  buttonContainer: {
+    width: 320,
+    height: 68,
+    marginHorizontal: 20,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 3,
+  },
+  button: {
+    borderRadius: 10,
+    width: '100%',
+    height: '100%',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexDirection: 'row',
+  },
+  buttonIcon: {
+    paddingRight: 8,
+  },
+  buttonLabel: {
+    color: '#fff',
+    fontSize: 16,
+  },
+});

--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -1,10 +1,37 @@
 import { StyleSheet, View, Pressable, Text } from 'react-native';
+import { FontAwesome } from '@expo/vector-icons';
 
 type Props = {
   label: string;
+  theme?: 'primary';
 };
 
-export default function Button({ label }: Props) {
+export default function Button({ label, theme }: Props) {
+  if (theme === 'primary') {
+    return (
+      <View
+        style={[
+          styles.buttonContainer,
+          { borderWidth: 4, borderColor: '#ffd33d', borderRadius: 18 },
+        ]}
+      >
+        <Pressable
+          style={[styles.button, { backgroundColor: '#fff' }]}
+          onPress={() => alert('You pressed a button!')}
+        >
+          <FontAwesome
+            name="picture-o"
+            size={18}
+            color="#25292e"
+            style={styles.buttonIcon}
+          />
+          <Text style={[styles.buttonLabel, { color: '#25292e' }]}>
+            {label}
+          </Text>
+        </Pressable>
+      </View>
+    );
+  }
   return (
     <View style={styles.buttonContainer}>
       <Pressable

--- a/components/ImageViewer.tsx
+++ b/components/ImageViewer.tsx
@@ -1,0 +1,16 @@
+import { StyleSheet } from 'react-native';
+import { Image } from 'expo-image';
+
+type Props = { imgSource: string };
+
+export default function ImageViewer({ imgSource }: Props) {
+  return <Image source={imgSource} style={styles.image} />;
+}
+
+const styles = StyleSheet.create({
+  image: {
+    width: 320,
+    height: 440,
+    borderRadius: 18,
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "expo-constants": "~17.0.3",
         "expo-font": "~13.0.2",
         "expo-haptics": "~14.0.0",
+        "expo-image": "~2.0.3",
         "expo-linking": "~7.0.3",
         "expo-router": "~4.0.15",
         "expo-splash-screen": "~0.29.18",
@@ -6454,6 +6455,22 @@
       "integrity": "sha512-5tYJN+2axYF22BtG1elBQAV1aZPUOCtr9sItClfm4jDoekGiPCxZG/nylcA3DVh2bUHMSll4Y98qjFFFhwZ1Cw==",
       "peerDependencies": {
         "expo": "*"
+      }
+    },
+    "node_modules/expo-image": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expo-image/-/expo-image-2.0.3.tgz",
+      "integrity": "sha512-+YnHTQv8jbXaut3FY7TDhNiSiGZ927C329mHvTZWV4Fyj32/Hjhhmk7dqq9I6LrA0nqBBiJjFj3u6VdHvCBnZg==",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*",
+        "react-native-web": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-web": {
+          "optional": true
+        }
       }
     },
     "node_modules/expo-keep-awake": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "react-native-safe-area-context": "4.12.0",
     "react-native-screens": "~4.4.0",
     "react-native-web": "~0.19.13",
-    "react-native-webview": "13.12.5"
+    "react-native-webview": "13.12.5",
+    "expo-image": "~2.0.3"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
## Tutorial Video
https://youtu.be/3rcOP8xDwTQ?si=pcYoXYyU5KP2-XFl

### [Display the image](https://github.com/araaakang/zest/pull/4/commits/db070319bb50d6e69669ad00a3fb444ab332b9b9)
- 透過 `npx expo install expo-image` 指令安裝 expo-image 
- expo-image `Image` 元件 source 屬性

## [Divide components into files](https://github.com/araaakang/zest/pull/4/commits/dfca456c101da655da9be8280bc17dc32da7a0d6)
- 將圖片部分抽成元件 ImageViewer.tsx，可根據不同 imgSource 顯示不同圖片

## [Create buttons using Pressable](https://github.com/araaakang/zest/pull/4/commits/049836c4ea04ce1e8ea54c74bb704d846e0975b9)
- Button 元件及 react-native提供的 Pressable
- `Pressable` 元件 onPress 事件跳出彈窗文字提示

## [Enhance the reusable button component](https://github.com/araaakang/zest/pull/4/commits/e323c81a97210cfc69a8ed2ec91f8d241c8c53a8)
- 傳入 theme 可選 prop 增加元件複用性

完成畫面
<img width="360" alt="image" src="https://github.com/user-attachments/assets/5b5faa59-702c-4ad7-aa4e-27def62a1f44" />

## Additional Note
### 路徑別名（Alias）
```javascript
const PlaceholderImage = require('../../assets/images/background-image.png');
// 從上面寫法改成下面的
const PlaceholderImage = require('@/assets/images/background-image.png');
```

可以這樣寫是因為在 tsconfig.json 從一開始建立專案就預設設定好了路徑別名（Alias）：

```javascript
  "compilerOptions": {
    "paths": {
      "@/*": [
        "./*"
      ]
    }
  },
```
當路徑很深（如 ../../../）時，相對路徑會變得難以閱讀和管理。
使用絕對路徑可以更快地理解檔案的位置，提升可讀性並減少錯誤。