### PR TITLE
Tutorial#4 Use the selected image  How to use an image picker

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,10 +1,22 @@
 import { View, StyleSheet } from 'react-native';
 import ImageViewer from '@/components/ImageViewer';
 import Button from '@/components/Button';
+import * as ImagePicker from 'expo-image-picker';
 
 const PlaceholderImage = require('@/assets/images/background-image.png');
 
 export default function Index() {
+  const pickImageAsync = async () => {
+    let result = await ImagePicker.launchImageLibraryAsync({
+      allowsEditing: true,
+      quality: 1,
+    });
+    if (!result.canceled) {
+      console.log(result);
+    } else {
+      alert('You did not select any image.');
+    }
+  };
   return (
     <View style={styles.container}>
       <View style={styles.imageContainer}>

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -23,7 +23,11 @@ export default function Index() {
         <ImageViewer imgSource={PlaceholderImage} />
       </View>
       <View style={styles.footerContainer}>
-        <Button label="Choose a photo" theme="primary" />
+        <Button
+          onPress={pickImageAsync}
+          label="Choose a photo"
+          theme="primary"
+        />
         <Button label="Use this photo" />
       </View>
     </View>

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -2,16 +2,21 @@ import { View, StyleSheet } from 'react-native';
 import ImageViewer from '@/components/ImageViewer';
 import Button from '@/components/Button';
 import * as ImagePicker from 'expo-image-picker';
+import { useState } from 'react';
 
 const PlaceholderImage = require('@/assets/images/background-image.png');
 
 export default function Index() {
+  const [selectedImage, setSelectedImage] = useState<string | undefined>(
+    undefined
+  );
   const pickImageAsync = async () => {
     let result = await ImagePicker.launchImageLibraryAsync({
       allowsEditing: true,
       quality: 1,
     });
     if (!result.canceled) {
+      setSelectedImage(result.assets[0].uri);
       console.log(result);
     } else {
       alert('You did not select any image.');
@@ -20,7 +25,7 @@ export default function Index() {
   return (
     <View style={styles.container}>
       <View style={styles.imageContainer}>
-        <ImageViewer imgSource={PlaceholderImage} />
+        <ImageViewer imgSource={selectedImage || PlaceholderImage} />
       </View>
       <View style={styles.footerContainer}>
         <Button

--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -4,9 +4,10 @@ import { FontAwesome } from '@expo/vector-icons';
 type Props = {
   label: string;
   theme?: 'primary';
+  onPress?: () => void;
 };
 
-export default function Button({ label, theme }: Props) {
+export default function Button({ label, theme, onPress }: Props) {
   if (theme === 'primary') {
     return (
       <View
@@ -17,7 +18,7 @@ export default function Button({ label, theme }: Props) {
       >
         <Pressable
           style={[styles.button, { backgroundColor: '#fff' }]}
-          onPress={() => alert('You pressed a button!')}
+          onPress={onPress}
         >
           <FontAwesome
             name="picture-o"
@@ -34,10 +35,7 @@ export default function Button({ label, theme }: Props) {
   }
   return (
     <View style={styles.buttonContainer}>
-      <Pressable
-        style={styles.button}
-        onPress={() => alert('You pressed a button!')}
-      >
+      <Pressable style={styles.button} onPress={onPress}>
         <Text style={styles.buttonLabel}>{label}</Text>
       </Pressable>
     </View>

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "expo-font": "~13.0.2",
         "expo-haptics": "~14.0.0",
         "expo-image": "~2.0.3",
+        "expo-image-picker": "~16.0.3",
         "expo-linking": "~7.0.3",
         "expo-router": "~4.0.15",
         "expo-splash-screen": "~0.29.18",
@@ -6471,6 +6472,25 @@
         "react-native-web": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-image-loader": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-5.0.0.tgz",
+      "integrity": "sha512-Eg+5FHtyzv3Jjw9dHwu2pWy4xjf8fu3V0Asyy42kO+t/FbvW/vjUixpTjPtgKQLQh+2/9Nk4JjFDV6FwCnF2ZA==",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-picker": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-16.0.3.tgz",
+      "integrity": "sha512-c4IOqIQOtx8puWWU4fVsJhuGiAhH6gAIdrVzhimOXSEUHnfxCckRYzvznbd/0cuvaA5y9H0CSYrxpTUc/0WNVw==",
+      "dependencies": {
+        "expo-image-loader": "~5.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-keep-awake": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "react-native-screens": "~4.4.0",
     "react-native-web": "~0.19.13",
     "react-native-webview": "13.12.5",
-    "expo-image": "~2.0.3"
+    "expo-image": "~2.0.3",
+    "expo-image-picker": "~16.0.3"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
## Tutorial Video
https://youtu.be/iEQZU58naS8?si=XZaruSY-mgPoJB3s

## [Pick an image from the device's media library](https://github.com/araaakang/zest/pull/5/commits/5281b106440017156aa18366a234758f71b37d37)
- 一樣透過 `expo install` 安裝 expo-image-picker
- `import * as ImagePicker from 'expo-image-picker';` 匯入這個套件來使用
- pickImageAsync = 用來選裝置上相片的非同步函式：用 `ImagePicker.launchImageLibraryAsync` 打開相片庫，讓使用者選擇圖片

## [Update the button component](https://github.com/araaakang/zest/pull/5/commits/8098ff0bf53aa07e3953cd4ddb6a433642ea4393)
設定好按鈕 onPress事件觸發，照片有成功選到的話 console.log 會印出相對應的資訊：
![image](https://github.com/user-attachments/assets/f7ff78f5-2be8-477a-9bae-32605d9d32d9)
但這個時候還不會把畫面上照片替換成選到的照片

## [Use the selected image](https://github.com/araaakang/zest/pull/5/commits/18609afe13664f0e1b9cba9192b3935d50b94b20)
useState 的 setState 部分綁定觸發打開相片庫選照片的 onPress 事件
成功的話 state 即可取得上傳的圖片並作為 imgSource 傳給 ImageViewer 元件

注意到這行！
imgSource 一開始直接換成 selectedImage 的話會噴錯，因為型別是 string
所以這邊加上 `|| PlaceholderImage` 作為沒有選擇新照片時的預設照片
```javascript
 <ImageViewer imgSource={selectedImage || PlaceholderImage} />
```

上傳圖片成功，將原先圖片換掉：
<img width="360" alt="image" src="https://github.com/user-attachments/assets/c08f9b7a-12bd-445c-ba19-95487df2df0c" />

未上傳圖片時跳 alert：
<img width="360" alt="image" src="https://github.com/user-attachments/assets/6957446f-5f0a-46aa-8efb-52d2e7d1a8fc" />

