### PR TITLE
Tutorial#5 How to create a modal in React Native

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -10,6 +10,8 @@ export default function Index() {
   const [selectedImage, setSelectedImage] = useState<string | undefined>(
     undefined
   );
+  const [showAppOptions, setShowAppOptions] = useState<boolean>(false);
+
   const pickImageAsync = async () => {
     let result = await ImagePicker.launchImageLibraryAsync({
       allowsEditing: true,
@@ -17,6 +19,7 @@ export default function Index() {
     });
     if (!result.canceled) {
       setSelectedImage(result.assets[0].uri);
+      setShowAppOptions(true);
       console.log(result);
     } else {
       alert('You did not select any image.');
@@ -27,14 +30,21 @@ export default function Index() {
       <View style={styles.imageContainer}>
         <ImageViewer imgSource={selectedImage || PlaceholderImage} />
       </View>
-      <View style={styles.footerContainer}>
-        <Button
-          onPress={pickImageAsync}
-          label="Choose a photo"
-          theme="primary"
-        />
-        <Button label="Use this photo" />
-      </View>
+      {showAppOptions ? (
+        <View />
+      ) : (
+        <View style={styles.footerContainer}>
+          <Button
+            label="Choose a photo"
+            theme="primary"
+            onPress={pickImageAsync}
+          />
+          <Button
+            label="Use this photo"
+            onPress={() => setShowAppOptions(true)}
+          />
+        </View>
+      )}
     </View>
   );
 }

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,6 +1,8 @@
 import { View, StyleSheet } from 'react-native';
 import ImageViewer from '@/components/ImageViewer';
 import Button from '@/components/Button';
+import IconButton from '@/components/IconButton';
+import CircleButton from '@/components/CircleButton';
 import * as ImagePicker from 'expo-image-picker';
 import { useState } from 'react';
 
@@ -25,13 +27,33 @@ export default function Index() {
       alert('You did not select any image.');
     }
   };
+  const onReset = () => {
+    setShowAppOptions(false);
+  };
+  const onAddSticker = () => {
+    //
+  };
+  const onSaveImageAsync = () => {
+    //
+  };
+
   return (
     <View style={styles.container}>
       <View style={styles.imageContainer}>
         <ImageViewer imgSource={selectedImage || PlaceholderImage} />
       </View>
       {showAppOptions ? (
-        <View />
+        <View style={styles.optionsContainer}>
+          <View style={styles.optionsRow}>
+            <IconButton icon="refresh" label="Reset" onPress={onReset} />
+            <CircleButton onPress={onAddSticker} />
+            <IconButton
+              icon="save-alt"
+              label="Save"
+              onPress={onSaveImageAsync}
+            />
+          </View>
+        </View>
       ) : (
         <View style={styles.footerContainer}>
           <Button
@@ -61,5 +83,13 @@ const styles = StyleSheet.create({
   footerContainer: {
     flex: 1 / 3,
     alignItems: 'center',
+  },
+  optionsContainer: {
+    position: 'absolute',
+    bottom: 80,
+  },
+  optionsRow: {
+    alignItems: 'center',
+    flexDirection: 'row',
   },
 });

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -5,6 +5,7 @@ import IconButton from '@/components/IconButton';
 import CircleButton from '@/components/CircleButton';
 import EmojiPicker from '@/components/EmojiPicker';
 import EmojiList from '@/components/EmojiList';
+import EmojiSticker from '@/components/EmojiSticker';
 import * as ImagePicker from 'expo-image-picker';
 import { useState } from 'react';
 
@@ -48,6 +49,9 @@ export default function Index() {
     <View style={styles.container}>
       <View style={styles.imageContainer}>
         <ImageViewer imgSource={selectedImage || PlaceholderImage} />
+        {pickedEmoji && (
+          <EmojiSticker imageSize={40} stickerSource={pickedEmoji} />
+        )}
       </View>
       {showAppOptions ? (
         <View style={styles.optionsContainer}>

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -4,6 +4,7 @@ import Button from '@/components/Button';
 import IconButton from '@/components/IconButton';
 import CircleButton from '@/components/CircleButton';
 import EmojiPicker from '@/components/EmojiPicker';
+import EmojiList from '@/components/EmojiList';
 import * as ImagePicker from 'expo-image-picker';
 import { useState } from 'react';
 
@@ -13,6 +14,7 @@ export default function Index() {
   const [selectedImage, setSelectedImage] = useState<string | undefined>(
     undefined
   );
+  const [pickedEmoji, setPickedEmoji] = useState<string | undefined>(undefined);
   const [showAppOptions, setShowAppOptions] = useState<boolean>(false);
   const [isModalVisible, setIsModalVisible] = useState<boolean>(false);
 
@@ -73,7 +75,7 @@ export default function Index() {
         </View>
       )}
       <EmojiPicker isVisible={isModalVisible} onClose={onModalClose}>
-        <></>
+        <EmojiList onSelect={setPickedEmoji} onCloseModal={onModalClose} />
       </EmojiPicker>
     </View>
   );

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -3,6 +3,7 @@ import ImageViewer from '@/components/ImageViewer';
 import Button from '@/components/Button';
 import IconButton from '@/components/IconButton';
 import CircleButton from '@/components/CircleButton';
+import EmojiPicker from '@/components/EmojiPicker';
 import * as ImagePicker from 'expo-image-picker';
 import { useState } from 'react';
 
@@ -13,6 +14,7 @@ export default function Index() {
     undefined
   );
   const [showAppOptions, setShowAppOptions] = useState<boolean>(false);
+  const [isModalVisible, setIsModalVisible] = useState<boolean>(false);
 
   const pickImageAsync = async () => {
     let result = await ImagePicker.launchImageLibraryAsync({
@@ -30,8 +32,11 @@ export default function Index() {
   const onReset = () => {
     setShowAppOptions(false);
   };
+  const onModalClose = () => {
+    setIsModalVisible(false);
+  };
   const onAddSticker = () => {
-    //
+    setIsModalVisible(true);
   };
   const onSaveImageAsync = () => {
     //
@@ -67,6 +72,9 @@ export default function Index() {
           />
         </View>
       )}
+      <EmojiPicker isVisible={isModalVisible} onClose={onModalClose}>
+        <></>
+      </EmojiPicker>
     </View>
   );
 }

--- a/components/CircleButton.tsx
+++ b/components/CircleButton.tsx
@@ -1,0 +1,35 @@
+import { View, Pressable, StyleSheet } from 'react-native';
+import MaterialIcons from '@expo/vector-icons/MaterialIcons';
+
+type Props = {
+  onPress?: () => void;
+};
+
+export default function CircleButton({ onPress }: Props) {
+  return (
+    <View style={styles.circleButtonContainer}>
+      <Pressable style={styles.circleButton} onPress={onPress}>
+        <MaterialIcons name="add" size={38} color="#25292e" />
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  circleButtonContainer: {
+    width: 84,
+    height: 84,
+    marginHorizontal: 60,
+    borderWidth: 4,
+    borderColor: '#ffd33d',
+    borderRadius: 42,
+    padding: 3,
+  },
+  circleButton: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    borderRadius: 42,
+    backgroundColor: '#fff',
+  },
+});

--- a/components/EmojiList.tsx
+++ b/components/EmojiList.tsx
@@ -1,0 +1,53 @@
+import { useState } from 'react';
+import { StyleSheet, FlatList, Platform, Pressable } from 'react-native';
+import { Image } from 'expo-image';
+
+type Props = {
+  onSelect: (image: string) => void;
+  onCloseModal: () => void;
+};
+
+export default function EmojiList({ onSelect, onCloseModal }: Props) {
+  const [emoji] = useState([
+    require('@/assets/images/emoji1.png'),
+    require('@/assets/images/emoji2.png'),
+    require('@/assets/images/emoji3.png'),
+    require('@/assets/images/emoji4.png'),
+    require('@/assets/images/emoji5.png'),
+    require('@/assets/images/emoji6.png'),
+  ]);
+  return (
+    <FlatList
+      horizontal
+      showsHorizontalScrollIndicator={Platform.OS === 'web'}
+      data={emoji}
+      contentContainerStyle={styles.listContainer}
+      renderItem={({ item, index }) => (
+        <Pressable
+          onPress={() => {
+            onSelect(item);
+            onCloseModal();
+          }}
+        >
+          <Image source={item} key={index} style={styles.image} />
+        </Pressable>
+      )}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  listContainer: {
+    borderTopRightRadius: 10,
+    borderTopLeftRadius: 10,
+    paddingHorizontal: 20,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  image: {
+    width: 100,
+    height: 100,
+    marginRight: 20,
+  },
+});

--- a/components/EmojiPicker.tsx
+++ b/components/EmojiPicker.tsx
@@ -1,0 +1,50 @@
+import { Modal, View, Text, Pressable, StyleSheet } from 'react-native';
+import MaterialIcons from '@expo/vector-icons/MaterialIcons';
+
+type Props = {
+  isVisible: boolean;
+  children: React.ReactNode;
+  onClose: () => void;
+};
+
+export default function CircleButton({ isVisible, children, onClose }: Props) {
+  return (
+    <Modal animationType="slide" transparent={true} visible={isVisible}>
+      <View style={styles.modalContent}>
+        <View style={styles.titleContainer}>
+          <Text style={styles.title}>Choose a sticker</Text>
+          <Pressable onPress={onClose}>
+            <MaterialIcons name="close" size={22} color="#fff" />
+          </Pressable>
+        </View>
+        {children}
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  modalContent: {
+    height: '25%',
+    width: '100%',
+    backgroundColor: '#25292e',
+    borderTopRightRadius: 18,
+    borderTopLeftRadius: 18,
+    position: 'absolute',
+    bottom: 0,
+  },
+  titleContainer: {
+    height: '16%',
+    backgroundColor: '#464c55',
+    borderTopRightRadius: 10,
+    borderTopLeftRadius: 10,
+    paddingHorizontal: 20,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  title: {
+    color: '#fff',
+    fontSize: 16,
+  },
+});

--- a/components/EmojiSticker.tsx
+++ b/components/EmojiSticker.tsx
@@ -1,0 +1,18 @@
+import { View } from 'react-native';
+import { Image } from 'expo-image';
+
+type Props = {
+  imageSize: number;
+  stickerSource: string;
+};
+
+export default function CircleButton({ imageSize, stickerSource }: Props) {
+  return (
+    <View style={{ top: -350 }}>
+      <Image
+        source={stickerSource}
+        style={{ width: imageSize, height: imageSize }}
+      />
+    </View>
+  );
+}

--- a/components/IconButton.tsx
+++ b/components/IconButton.tsx
@@ -1,0 +1,28 @@
+import { Pressable, StyleSheet, Text } from 'react-native';
+import MaterialIcons from '@expo/vector-icons/MaterialIcons';
+
+type Props = {
+  icon: keyof typeof MaterialIcons.glyphMap;
+  label: string;
+  onPress?: () => void;
+};
+
+export default function IconButton({ icon, label, onPress }: Props) {
+  return (
+    <Pressable style={styles.iconButton} onPress={onPress}>
+      <MaterialIcons name={icon} size={24} color="#fff" />
+      <Text style={styles.iconButtonLabel}>{label}</Text>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  iconButton: {
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  iconButtonLabel: {
+    color: '#fff',
+    marginTop: 12,
+  },
+});


### PR DESCRIPTION
## Tutorial Video
https://youtu.be/HRAMzrBwVeo?si=qfD3tfPzpXK_2Dn1

## [Declare a state variable to show buttons](https://github.com/araaakang/zest/pull/6/commits/dbfe84712e4097da576ee12f902dc9f7d511cddc)

## [Add buttons to add stickers & save or reset image](https://github.com/araaakang/zest/pull/6/commits/09520ff2ed62f4d15de1831c444eed38e0747dba)
<img width="361" alt="image" src="https://github.com/user-attachments/assets/29fc2da3-e764-48f1-bda4-1b3c8ac31bbe" />

## [Create an Emoji picker modal](https://github.com/araaakang/zest/pull/6/commits/5b7b287245d9a7ef09667ecd1d5e33d0faf3df32)
### React 原生 Modal 元件
- animationType 動畫：設定 "slide" or "fade"，分別可以讓 Modal 出現消失的動畫以「滑入滑出」或「淡入淡出」呈現

EmojiPicker 這個元件接收一個 children(react node) 作為 props 傳入，實際上是這樣寫的，在中間夾入<></>：
```javascript
<EmojiPicker isVisible={isModalVisible} onClose={onModalClose}>
    <></>
</EmojiPicker>
```
為了讓後續步驟可以在 EmojiPicker 內接著渲染 emoji list
<img width="361" alt="image" src="https://github.com/user-attachments/assets/1cc05598-2c59-434b-8296-c1e44f7108ba" />

## [Display a list of emoji](https://github.com/araaakang/zest/pull/6/commits/e12f1a27e875819cb59efd1421762e70e4b4c653)
### React Native 原生 Flatlist 元件
- 高效渲染： 只渲染當前可見區域的項目，提高性能
- 支持滾動： 內建滾動功能，能夠在長列表中快速滾
- lazy loading：在用戶滾動時動態加載更多內容
<img width="361" alt="image" src="https://github.com/user-attachments/assets/1e2ab1c9-caa3-416d-baf7-ac5078590b35" />
<img width="361" alt="image" src="https://github.com/user-attachments/assets/cabe1bf7-5a03-4f1c-bc86-de7a84dc64b0" />

## [Display the selected emoji](https://github.com/araaakang/zest/pull/6/commits/88b8c0e7a24045295a8a0a559f924bec3e7c00ed)
<img width="361" alt="image" src="https://github.com/user-attachments/assets/fa33a9a3-0e6e-4c5c-8ce7-3d84cc6231f5" />
