### PR TITLE
Tutotial#6 How to add gestures to an Expo App

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,14 +1,15 @@
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
 
 export default function RootLayout() {
   return (
-    <>
+    <GestureHandlerRootView style={{ flex: 1 }}>
       <StatusBar style="light" />
       <Stack>
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
         <Stack.Screen name="+not-found" options={{ headerShown: false }} />
       </Stack>
-    </>
+    </GestureHandlerRootView>
   );
 }

--- a/components/EmojiSticker.tsx
+++ b/components/EmojiSticker.tsx
@@ -1,5 +1,10 @@
-import { View } from 'react-native';
-import { Image } from 'expo-image';
+import { ImageSourcePropType, View } from 'react-native';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+  withSpring,
+} from 'react-native-reanimated';
 
 type Props = {
   imageSize: number;
@@ -7,12 +12,31 @@ type Props = {
 };
 
 export default function CircleButton({ imageSize, stickerSource }: Props) {
+  const scaleImage = useSharedValue(imageSize);
+  const doubleTap = Gesture.Tap()
+    .numberOfTaps(2)
+    .onStart(() => {
+      if (scaleImage.value !== imageSize * 2) {
+        scaleImage.value = scaleImage.value * 2;
+      } else {
+        scaleImage.value = Math.round(scaleImage.value / 2);
+      }
+    });
+  const imageStyle = useAnimatedStyle(() => {
+    return {
+      width: withSpring(scaleImage.value),
+      height: withSpring(scaleImage.value),
+    };
+  });
   return (
     <View style={{ top: -350 }}>
-      <Image
-        source={stickerSource}
-        style={{ width: imageSize, height: imageSize }}
-      />
+      <GestureDetector gesture={doubleTap}>
+        <Animated.Image
+          source={stickerSource as ImageSourcePropType}
+          resizeMode={'contain'}
+          style={[imageStyle, { width: imageSize, height: imageSize }]}
+        />
+      </GestureDetector>
     </View>
   );
 }

--- a/components/EmojiSticker.tsx
+++ b/components/EmojiSticker.tsx
@@ -1,4 +1,4 @@
-import { ImageSourcePropType, View } from 'react-native';
+import { ImageSourcePropType } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   useAnimatedStyle,
@@ -12,6 +12,8 @@ type Props = {
 };
 
 export default function CircleButton({ imageSize, stickerSource }: Props) {
+  const translateX = useSharedValue(0);
+  const translateY = useSharedValue(0);
   const scaleImage = useSharedValue(imageSize);
   const doubleTap = Gesture.Tap()
     .numberOfTaps(2)
@@ -28,15 +30,30 @@ export default function CircleButton({ imageSize, stickerSource }: Props) {
       height: withSpring(scaleImage.value),
     };
   });
+  const drag = Gesture.Pan().onChange((event) => {
+    translateX.value += event.changeX;
+    translateY.value += event.changeY;
+  });
+  const containerStyle = useAnimatedStyle(() => {
+    return {
+      transform: [
+        { translateX: translateX.value },
+        { translateY: translateY.value },
+      ],
+    };
+  });
+
   return (
-    <View style={{ top: -350 }}>
-      <GestureDetector gesture={doubleTap}>
-        <Animated.Image
-          source={stickerSource as ImageSourcePropType}
-          resizeMode={'contain'}
-          style={[imageStyle, { width: imageSize, height: imageSize }]}
-        />
-      </GestureDetector>
-    </View>
+    <GestureDetector gesture={drag}>
+      <Animated.View style={[containerStyle, { top: -350 }]}>
+        <GestureDetector gesture={doubleTap}>
+          <Animated.Image
+            source={stickerSource as ImageSourcePropType}
+            resizeMode={'contain'}
+            style={[imageStyle, { width: imageSize, height: imageSize }]}
+          />
+        </GestureDetector>
+      </Animated.View>
+    </GestureDetector>
   );
 }


### PR DESCRIPTION
## Tutorial Video
https://youtu.be/0q48LLvTGDU?si=4S90D6b9J5CKF3eU

## Intro
在手機應用程式開發中，gesture（手勢）是指用戶透過觸控操作進行的交互方式。開發者會使用手勢來設計應用程式中用戶與界面的互動，例如點擊、滑動、縮放、長按等。手勢可以讓用戶以更加直觀和自然的方式與應用程式進行互動，並且能夠提升使用者體驗。
影片中會加入兩個 gesture，搭配使用的是在用 expo 建立專案時就一起安裝了的 library：react-native-reanimated

![image](https://github.com/user-attachments/assets/9a3a97bf-254c-4684-98d9-9727c2b3aa82)

## [Add GestureHandlerRootView](https://github.com/araaakang/zest/pull/7/commits/fc2c1d1f169f82ee50957595d1ceafb8293532e3)

## [Add a tap gesture](https://github.com/araaakang/zest/pull/7/commits/627818c0b6220ae1ef2ff9e191ded72eb92b64b6)
withSpring 是 React Native 中的動畫函數，來自於 react-native-reanimated 或 react-native-gesture-handler 等動畫庫。它用來創建彈簧效果的動畫，通常用於使動畫具有自然、流暢的過渡感覺

點兩下 emoji 會放大縮小
<img width="361" alt="image" src="https://github.com/user-attachments/assets/99efc5f5-cade-4b1e-aa5e-4230ae19396c" />

<img width="361" alt="image" src="https://github.com/user-attachments/assets/44e65655-bfb0-4f1c-ba7c-49bf93c0cdd0" />

## [Add a pan gesture](https://github.com/araaakang/zest/pull/7/commits/947dd24f5434a5809d76f4d67682ae4796e9bff6)

https://github.com/user-attachments/assets/27ba9beb-a143-4785-ab56-457bb5cf6003

## Addtional Note
- Animated.View 是 React Native 中 Animated 模組的一部分，專門用來處理動畫
- View 則是普通的容器組件，無法進行動畫處理。

簡單來說，View 是一個靜態的容器，而 Animated.View 讓你能夠在其上應用動畫，從而創建更加動態和吸引人的用戶界面。

Animated.Image 和 Animated.View 的原理是相同的，都是用來將動畫應用到原本的 Image 或 View 組件上。換句話說，Animated.Image 使得圖片可以像 Animated.View 一樣支持動畫效果。

- Image：這是 React Native 中用來顯示圖片的基本組件。它本身不支持動畫，只能顯示靜態圖片
- Animated.Image：這是 Animated 模組提供的功能，可以讓你對圖片進行動畫處理。你可以對圖片的樣式屬性（如位置、透明度、縮放等）進行動態變化。