### PR TITLE
Tutorial#7 How to take and save screenshots

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -7,17 +7,25 @@ import EmojiPicker from '@/components/EmojiPicker';
 import EmojiList from '@/components/EmojiList';
 import EmojiSticker from '@/components/EmojiSticker';
 import * as ImagePicker from 'expo-image-picker';
-import { useState } from 'react';
+import * as MediaLibrary from 'expo-media-library';
+import { useState, useEffect } from 'react';
 
 const PlaceholderImage = require('@/assets/images/background-image.png');
 
 export default function Index() {
+  const [permissionResponse, requestPermission] = MediaLibrary.usePermissions();
   const [selectedImage, setSelectedImage] = useState<string | undefined>(
     undefined
   );
   const [pickedEmoji, setPickedEmoji] = useState<string | undefined>(undefined);
   const [showAppOptions, setShowAppOptions] = useState<boolean>(false);
   const [isModalVisible, setIsModalVisible] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (!permissionResponse?.granted) {
+      requestPermission();
+    }
+  }, []);
 
   const pickImageAsync = async () => {
     let result = await ImagePicker.launchImageLibraryAsync({

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -8,11 +8,13 @@ import EmojiList from '@/components/EmojiList';
 import EmojiSticker from '@/components/EmojiSticker';
 import * as ImagePicker from 'expo-image-picker';
 import * as MediaLibrary from 'expo-media-library';
-import { useState, useEffect } from 'react';
+import { captureRef } from 'react-native-view-shot';
+import { useState, useEffect, useRef } from 'react';
 
 const PlaceholderImage = require('@/assets/images/background-image.png');
 
 export default function Index() {
+  const imageRef = useRef(null);
   const [permissionResponse, requestPermission] = MediaLibrary.usePermissions();
   const [selectedImage, setSelectedImage] = useState<string | undefined>(
     undefined
@@ -55,7 +57,7 @@ export default function Index() {
 
   return (
     <View style={styles.container}>
-      <View style={styles.imageContainer}>
+      <View ref={imageRef} style={styles.imageContainer}>
         <ImageViewer imgSource={selectedImage || PlaceholderImage} />
         {pickedEmoji && (
           <EmojiSticker imageSize={40} stickerSource={pickedEmoji} />

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -51,13 +51,24 @@ export default function Index() {
   const onAddSticker = () => {
     setIsModalVisible(true);
   };
-  const onSaveImageAsync = () => {
-    //
+  const onSaveImageAsync = async () => {
+    try {
+      const localUri = await captureRef(imageRef, {
+        height: 440,
+        quality: 1,
+      });
+      await MediaLibrary.saveToLibraryAsync(localUri);
+      if (localUri) {
+        alert('Image saved to gallery!');
+      }
+    } catch (error) {
+      console.error('Failed to save image to gallery:', error);
+    }
   };
 
   return (
     <View style={styles.container}>
-      <View ref={imageRef} style={styles.imageContainer}>
+      <View ref={imageRef} collapsable={false} style={styles.imageContainer}>
         <ImageViewer imgSource={selectedImage || PlaceholderImage} />
         {pickedEmoji && (
           <EmojiSticker imageSize={40} stickerSource={pickedEmoji} />

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "expo-image": "~2.0.3",
         "expo-image-picker": "~16.0.3",
         "expo-linking": "~7.0.3",
+        "expo-media-library": "~17.0.4",
         "expo-router": "~4.0.15",
         "expo-splash-screen": "~0.29.18",
         "expo-status-bar": "~2.0.0",
@@ -32,6 +33,7 @@
         "react-native-reanimated": "~3.16.1",
         "react-native-safe-area-context": "4.12.0",
         "react-native-screens": "~4.4.0",
+        "react-native-view-shot": "~4.0.3",
         "react-native-web": "~0.19.13",
         "react-native-webview": "13.12.5"
       },
@@ -4809,6 +4811,14 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -5641,6 +5651,14 @@
       "integrity": "sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==",
       "dependencies": {
         "hyphenate-style-name": "^1.0.3"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/cssom": {
@@ -6515,6 +6533,15 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-media-library": {
+      "version": "17.0.4",
+      "resolved": "https://registry.npmjs.org/expo-media-library/-/expo-media-library-17.0.4.tgz",
+      "integrity": "sha512-5Fbv3dTlswO6ZcSYDF7zrCzsGly14rA0uKo+wyn3H4gEVgmLOZEzvAkLT4ELFq4RfT+zEuYCKPG1Sb1Q41e5kg==",
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/expo-modules-autolinking": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-2.0.4.tgz",
@@ -7346,6 +7373,18 @@
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/http-errors": {
       "version": "2.0.0",
@@ -11253,6 +11292,18 @@
         "react-native": "*"
       }
     },
+    "node_modules/react-native-view-shot": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/react-native-view-shot/-/react-native-view-shot-4.0.3.tgz",
+      "integrity": "sha512-USNjYmED7C0me02c1DxKA0074Hw+y/nxo+xJKlffMvfUWWzL5ELh/TJA/pTnVqFurIrzthZDPtDM7aBFJuhrHQ==",
+      "dependencies": {
+        "html2canvas": "^1.4.1"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/react-native-web": {
       "version": "0.19.13",
       "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.19.13.tgz",
@@ -12846,6 +12897,14 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -13213,6 +13272,14 @@
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/uuid": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,9 @@
     "react-native-web": "~0.19.13",
     "react-native-webview": "13.12.5",
     "expo-image": "~2.0.3",
-    "expo-image-picker": "~16.0.3"
+    "expo-image-picker": "~16.0.3",
+    "react-native-view-shot": "~4.0.3",
+    "expo-media-library": "~17.0.4"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
## Tutorial Video
https://youtu.be/Jft3_Yfr-p4?si=q3s6naXxdRnqqYmd
## [Install react-native-view-shot & expo-media-library](https://github.com/araaakang/zest/pull/8/commits/9091a7bea448ac46543d00fc7c4c3268c928b82a)
`npx install expo-media-library react-native-view-shot`

##[Prompt for permissions](https://github.com/araaakang/zest/pull/8/commits/59d5356b398399a30c8d975b2af4dd7b71b56ef9)
檢查並請求使用者授予應用程式對設備媒體庫（例如相片和影片）的權限
<img width="357" alt="image" src="https://github.com/user-attachments/assets/bd1b3783-71dd-410d-9ef5-a6baa2e6a665" />

1. **導入媒體庫模組**  
```javascript
import * as MediaQuery from 'expo-media-library';
```
- `expo-media-library` 是 Expo 提供的一個模組，用於操作設備的媒體庫（例如讀取、刪除或管理相片和影片）。
- `usePermissions` 是這個模組提供的一個 React Hook，用於處理權限請求。

2. **初始化權限相關的狀態和函式**  
```javascript
const [permissionResponse, requestPermission] = MediaQuery.usePermissions();
```
- `permissionResponse`:  儲存當前權限的狀態，例如是否已獲得授權（可能的值包括：`granted`（已授權）、`denied`（拒絕）、`undetermined`（尚未請求過權限））
- `requestPermission`:  用於向使用者發出權限請求的函式。調用時系統會彈出一個對話框，請求使用者允許存取媒體庫

3. **在元件載入時檢查並請求權限**  
```javascript
useEffect(() => {
  if (!permissionResponse?.granted) {
    requestPermission();
  }
}, []);
```
- **檢查權限：** 如果 `permissionResponse` 不存在或 `granted` 狀態為 `false`，代表尚未獲得授權
- **請求權限：** 檢測到尚未授權時，執行這個函式向使用者請求授權

## [Create a ref to save the current view](https://github.com/araaakang/zest/pull/8/commits/1c49268a0b83a2545e1b7dadc70c76deba0ed632)
建立一個 ref 以便在後續操作中能夠捕捉並保存該視圖的畫面（screenshot）
```javascript
import { captureRef } from 'react-native-view-shot';
```
`captureRef`：來自 react-native-view-shot 的函式，用於將 React Native 的視圖轉換為影像（即截圖）。它接受一個視圖的引用（ref）作為參數，然後返回該視圖的影像文件或 base64 字符串。

## [Capture a screenshot and save it](https://github.com/araaakang/zest/pull/8/commits/2df92b2ab61e824aeaed1c83bf0e7961b8a8cad8)
<img width="357" alt="image" src="https://github.com/user-attachments/assets/29be8c16-6bb0-4b91-aeb4-166fd7b9b3a4" />
<img width="357" alt="image" src="https://github.com/user-attachments/assets/cedac71c-124e-42fe-899d-0b42a4786bfe" />

## Additional Note
<img width="357" alt="image" src="https://github.com/user-attachments/assets/0ec82ed2-874c-4295-b9f0-84f12edfcf6f" />

也有人在影片底下留言：「我在 SDK 52 版本中也遇到過截圖無法 work 的問題，但爬文看了文件後發現只要在 `<View ref={imageRef} style={styles.imageContainer}>` 這一行中加入 `collapsable={false}` 就解決了。」
<img width="981" alt="image" src="https://github.com/user-attachments/assets/ce551fff-c245-4aee-b89d-701d594003ff" />

### 解決 react-native-view-shot 截圖失敗的問題：為何需要設置 collapsable={false}
在 React Native 中，`collapsable={false}` 是一個用來設置是否讓元件在渲染時被壓縮的屬性，對於 `captureRef` 用來截圖的場景，這個屬性非常重要。

### 什麼是 `collapsable`？
`collapsable` 是 React Native 中的屬性，用來告訴 React Native 是否應該將元件的佈局進行壓縮（collapse）。

### 為什麼要加 `collapsable={false}`？
當你使用 react-native-view-shot 的 captureRef 函式截圖時，React Native 可能會出於性能考慮，自動把沒有子元素或內容的視圖標記為“可壓縮”（collapsable），這樣會導致該視圖不被渲染，從而使 `captureRef` 找不到視圖來進行截圖。

加上 `collapsable={false}` 可以確保即使該視圖沒有顯示子元素，它仍然會在渲染樹中保留，這樣 `captureRef` 就可以正確地捕捉到這個視圖的快照（＝成功截圖）。
![image](https://github.com/user-attachments/assets/b8e158bf-fe03-47f4-9591-78627eec1e8c)

