### PR TITLE
Tutorial#8 How to handle platform differences

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,4 +1,4 @@
-import { View, StyleSheet } from 'react-native';
+import { View, StyleSheet, Platform } from 'react-native';
 import ImageViewer from '@/components/ImageViewer';
 import Button from '@/components/Button';
 import IconButton from '@/components/IconButton';
@@ -8,6 +8,7 @@ import EmojiList from '@/components/EmojiList';
 import EmojiSticker from '@/components/EmojiSticker';
 import * as ImagePicker from 'expo-image-picker';
 import * as MediaLibrary from 'expo-media-library';
+import domtoimage from 'dom-to-image';
 import { captureRef } from 'react-native-view-shot';
 import { useState, useEffect, useRef } from 'react';
 
@@ -52,18 +53,34 @@ export default function Index() {
     setIsModalVisible(true);
   };
   const onSaveImageAsync = async () => {
-    try {
-      const localUri = await captureRef(imageRef, {
-        height: 440,
-        quality: 1,
-      });
-      await MediaLibrary.saveToLibraryAsync(localUri);
-      if (localUri) {
-        alert('Image saved to gallery!');
+    if (Platform.OS === 'web') {
+      try {
+        // @ts-ignore
+        const dataUrl = await domtoimage.toJpeg(imageRef.current, {
+          height: 440,
+          width: 320,
+          quality: 0.95,
+        });
+        let link = document.createElement('a');
+        link.download = 'sticker-smash.jpeg';
+        link.href = dataUrl;
+        link.click();
+      } catch (error) {
+        console.error('Failed to save image to gallery:', error);
       }
-    } catch (error) {
-      console.error('Failed to save image to gallery:', error);
-    }
+    } else
+      try {
+        const localUri = await captureRef(imageRef, {
+          height: 440,
+          quality: 1,
+        });
+        await MediaLibrary.saveToLibraryAsync(localUri);
+        if (localUri) {
+          alert('Image saved to gallery!');
+        }
+      } catch (error) {
+        console.error('Failed to save image to gallery:', error);
+      }
   };
 
   return (

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
+        "@types/dom-to-image": "^2.6.7",
         "@types/jest": "^29.5.12",
         "@types/react": "~18.3.12",
         "@types/react-test-renderer": "^18.3.0",
@@ -3942,6 +3943,12 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
       "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="
+    },
+    "node_modules/@types/dom-to-image": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/@types/dom-to-image/-/dom-to-image-2.6.7.tgz",
+      "integrity": "sha512-me5VbCv+fcXozblWwG13krNBvuEOm6kA5xoa4RrjDJCNFOZSWR3/QLtOXimBHk1Fisq69Gx3JtOoXtg1N1tijg==",
+      "dev": true
     },
     "node_modules/@types/eslint": {
       "version": "9.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@expo/vector-icons": "^14.0.2",
         "@react-navigation/bottom-tabs": "^7.2.0",
         "@react-navigation/native": "^7.0.14",
+        "dom-to-image": "^2.6.0",
         "expo": "~52.0.23",
         "expo-blur": "~14.0.1",
         "expo-constants": "~17.0.3",
@@ -5910,6 +5911,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-to-image": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/dom-to-image/-/dom-to-image-2.6.0.tgz",
+      "integrity": "sha512-Dt0QdaHmLpjURjU7Tnu3AgYSF2LuOmksSGsUcE6ItvJoCWTBEmiMXcqBdNSAm9+QbbwD7JMoVsuuKX6ZVQv1qA=="
     },
     "node_modules/domexception": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
+    "@types/dom-to-image": "^2.6.7",
     "@types/jest": "^29.5.12",
     "@types/react": "~18.3.12",
     "@types/react-test-renderer": "^18.3.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@expo/vector-icons": "^14.0.2",
     "@react-navigation/bottom-tabs": "^7.2.0",
     "@react-navigation/native": "^7.0.14",
+    "dom-to-image": "^2.6.0",
     "expo": "~52.0.23",
     "expo-blur": "~14.0.1",
     "expo-constants": "~17.0.3",


### PR DESCRIPTION
## Tutorial Video
https://youtu.be/mEKQvF4irBM?si=Mm3y8IIS1h1HllKP

## [Install dom-to-image](https://github.com/araaakang/zest/pull/9/commits/632c8070bce9867bb78e540b19d6625913bac1d3)
dom-to-image 是一個用來將 HTML DOM 元素轉換成圖像的 JavaScript 套件。它可以讓你將網頁上的某個區塊（如 `<div>`, `<canvas>`, `<svg>` 等）生成一個圖片，並且支援各種圖片格式（如 PNG、JPEG、SVG 等）。
主要用來生成視覺截圖，適用於需要將網頁內容或 UI 元素轉換為圖片的場景。

### 主要功能
將 DOM 元素轉換為圖片
可以將 HTML 元素轉換為不同格式的圖片，例如 PNG 或 JPEG，並將其下載到用戶端。

### 支援自定義樣式
支援轉換 DOM 元素時保留樣式，包括背景色、邊框、文字顏色等。

### 簡單易用的 API
提供簡單的 API 可以讓開發者輕鬆將任何 HTML 元素轉換為圖片。

## [Add platform-specific code](https://github.com/araaakang/zest/pull/9/commits/db46f13aa8711990a41f3ae586362ddb27b0a976)


`Platform.OS` 是 React Native 提供的用來幫助開發者判斷當前運行的作業系統的 API，以便針對不同平台執行不同的邏輯，
使應用適配不同的設備和環境。常見的值有 'ios'、'android' 和 'web'。（OS 在這裡指的就是 作業系統（Operating System））

```javascript
if (Platform.OS === 'web') { ... }
```

網頁端部分利用了 domtoimage 套件來將 DOM 元素轉換為圖像，再用瀏覽器的 download 功能觸發下載：
```javascript
if (Platform.OS === 'web') {
    try {
      // @ts-ignore
      const dataUrl = await domtoimage.toJpeg(imageRef.current, {
        height: 440,
        width: 320,
        quality: 0.95,
      });
      let link = document.createElement('a');
      link.download = 'sticker-smash.jpeg';
      link.href = dataUrl;
      link.click();
    } catch (error) {
      console.error('Failed to save image to gallery:', error);
    }
  } else {
      // 手機端
  }
};
```

![image](https://github.com/user-attachments/assets/deef54db-2062-4489-bab5-2e156a840ed5)
![image](https://github.com/user-attachments/assets/1fe4f962-ef58-4923-90e9-78ee57a69d71)
<img width="871" alt="image" src="https://github.com/user-attachments/assets/9915e023-02ad-45a6-b191-2758054a05e3" />
<img width="320" alt="image" src="https://github.com/user-attachments/assets/a727f6cd-ac7d-4274-8eab-e763c6972472" />

## Additional Note
![image](https://github.com/user-attachments/assets/c9bfb745-a810-4a76-a172-76d09cede1de)

因為原先 `import domtoimage from 'dom-to-image';` 碰到型別定義問題
還需要另外再安裝 [@types/dom-to-image](https://www.npmjs.com/package/@types/dom-to-image)
